### PR TITLE
Added alternative way of authorization Git Project - HTTPS (using git_username and git_password)

### DIFF
--- a/docs/resources/project_git_repo.md
+++ b/docs/resources/project_git_repo.md
@@ -49,7 +49,8 @@ resource "looker_project_git_repo" "myrepo-project" {
 - `deploy_secret` (String) Secret Value for Authentication Webhook
 - `git_production_branch_name` (String) Git production branch name. Defaults to ~~master~~ main. Supported only in Looker 21.0 and higher.
 - `git_release_mgmt_enabled` (Boolean) Advanced Deploy Mode - Required for Webhook
-- `git_username` (String)
+- `git_username` (String) Git username for HTTPS authentication. For SSH authentication skip this option and create project_git_deploy_key resource.
+- `git_password` (String) Git password for HTTPS authentication. For SSH authentication skip this option and create project_git_deploy_key resource.
 - `is_example` (Boolean)
 - `pull_request_mode` (String) The git pull request policy for this project. Valid values are: `off`, `links`, `recommended`, `required`.
 - `use_git_cookie_auth` (Boolean) If true, the project uses a git cookie for authentication.

--- a/examples/resources/looker_project_git_repo/resource.tf
+++ b/examples/resources/looker_project_git_repo/resource.tf
@@ -2,4 +2,6 @@ resource "looker_project_git_repo" "myrepo-project" {
   project_id       = "project-id"
   git_remote_url   = "git@github.com:workspace/repo.git"
   git_service_name = "github"
+  git_username     = "username"
+  git_password     = "password"
 }

--- a/examples/resources/looker_project_git_repo/resource.tfshow
+++ b/examples/resources/looker_project_git_repo/resource.tfshow
@@ -11,4 +11,5 @@ resource "looker_project_git_repo" "myrepo-project" {
   git_production_branch_name = "main"
   use_git_cookie_auth        = false
   git_username               = "username"
+  git_password               = (sensitive value)
 }


### PR DESCRIPTION
Now Git Project can be Authorized via HTTPS . This is additional way of Authorization. For SSH authentication skip this option and create project_git_deploy_key resource.