### PR TITLE
fixed incorrect user data source documentation

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -8,7 +8,7 @@ description: |-
 
 ## Example Usage
 ```terraform
-resource "looker_user" "user" {
+data "looker_user" "user" {
   id = "123"
 }
 ```


### PR DESCRIPTION
The documentation of the user data source is incorrect and instructs to use the `resource` keyword instead of the `data` keyword.