### PR TITLE
bugfix: changes set types to list types to respect declaration ordering

### DIFF
--- a/internal/provider/resource_color_collection.go
+++ b/internal/provider/resource_color_collection.go
@@ -31,7 +31,7 @@ func resourceColorCollection() *schema.Resource {
 			},
 			"categoricalpalettes": {
 				Description: "Array of categorical palette definitions",
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Required:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -52,7 +52,7 @@ func resourceColorCollection() *schema.Resource {
 							Default:     "Categorical",
 						},
 						"colors": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
@@ -63,7 +63,7 @@ func resourceColorCollection() *schema.Resource {
 			},
 			"sequentialpalettes": {
 				Description: "Array of categorical palette definitions",
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Required:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -84,7 +84,7 @@ func resourceColorCollection() *schema.Resource {
 							Default:     "Sequential",
 						},
 						"stops": {
-							Type:        schema.TypeSet,
+							Type:        schema.TypeList,
 							Required:    true,
 							MinItems:    2,
 							Description: "Array of ColorStops in the palette",
@@ -118,7 +118,7 @@ func resourceColorCollection() *schema.Resource {
 			},
 			"divergingpalettes": {
 				Description: "Array of categorical palette definitions",
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Required:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -139,7 +139,7 @@ func resourceColorCollection() *schema.Resource {
 							Default:     "Diverging",
 						},
 						"stops": {
-							Type:        schema.TypeSet,
+							Type:        schema.TypeList,
 							Description: "Array of ColorStops in the palette",
 							Required:    true,
 							MinItems:    2,


### PR DESCRIPTION
fixes #54

This PR changes the Set types for colour collection declaration to List types in order to respect the ordering of colours used by Looker's color resolution mechanism. This impacts the UX of the End User.