### PR TITLE
Fix panic for non-existing data.looker_user

### DIFF
--- a/internal/provider/dataSource_user.go
+++ b/internal/provider/dataSource_user.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"golang.org/x/net/context"
+	"fmt"
 )
 
 var (
@@ -63,6 +64,9 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 		localUser, _, err := c.Users.ListByEmail(ctx, email.(string), &lookergo.ListOptions{})
 		if err != nil {
 			return diag.FromErr(err)
+		}
+		if len(localUser) == 0 {
+			return diag.FromErr(fmt.Errorf("User with email %s does not exist.", email))
 		}
 		user = lookergo.User(localUser[0])
 	}


### PR DESCRIPTION
Fixes https://github.com/devoteamgcloud/terraform-provider-looker/issues/82

Added an error message instead of a panic.

**Output** after PR:

```
Planning failed. Terraform encountered an error while generating this plan.                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                             
╷                                                                                                                                                                                                                                                                                                                            
│ Error: User with email test-user-new@test.xyz does not exist.                                                                                                                                                                                                                                                              
│                                                                                                                                                                                                                                                                                                                            
│   with data.looker_user.users,                                                                                                                                                                                                                                                                                             
│   on main.tf line 1, in data "looker_user" "users":                                                                                                                                                                                                                                                                        
│    1: data "looker_user" "users" {                                                                                                                                                                                                                                                                                         
│                                                                                                                                                                                                                                                                                                                            
╵                                                                                                                                                                                                                                                                                                                            
2024-03-26T12:22:36.373-0700 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"                                                                                                                                                             
2024-03-26T12:22:36.377-0700 [DEBUG] provider: plugin process exited: path=.terraform/providers/hashicorp.local/devoteamgcloud/looker/0.4.0/linux_amd64/terraform-provider-looker pid=2143581                                                                                                                                
2024-03-26T12:22:36.377-0700 [DEBUG] provider: plugin exited  
```                                                                      