### PR TITLE
 Multiple fixes for project_git_repo resource authentication and validation

### DIFF
--- a/internal/provider/resource_project_git_repo.go
+++ b/internal/provider/resource_project_git_repo.go
@@ -220,6 +220,8 @@ func resourceProjectGitRepoCreate(ctx context.Context, d *schema.ResourceData, m
 		payload.GitRemoteUrl = projectGitRepoUpdate.GitRemoteUrl
 		projectGitRepoUpdate.GitUsername = payload.GitUsername
 		projectGitRepoUpdate.GitPassword = payload.GitPassword
+		projectGitRepoUpdate.GitUsernameUserAttribute = payload.GitUsernameUserAttribute
+		projectGitRepoUpdate.GitPasswordUserAttribute = payload.GitPasswordUserAttribute
 		payload.GitServiceName = projectGitRepoUpdate.GitServiceName
 		if !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "https://") {
 			return diag.Errorf("HTTPS Authentication requires URL starts with http://..")

--- a/internal/provider/resource_project_git_repo.go
+++ b/internal/provider/resource_project_git_repo.go
@@ -308,8 +308,9 @@ func resourceProjectGitRepoUpdate(ctx context.Context, d *schema.ResourceData, m
 		projectGitRepoUpdate.DeploySecret = value.(string)
 	}
 	if value, ok := d.GetOk("git_username"); ok {
+		projectGitRepoUpdate.GitUsername = value.(string)
 		if value, ok := d.GetOk("git_password"); ok {
-			projectGitRepoUpdate.GitUsername = value.(string)
+			projectGitRepoUpdate.GitPassword = value.(string)
 		} else {
 			return diag.Errorf("git_username requires git_password")
 		}
@@ -321,7 +322,6 @@ func resourceProjectGitRepoUpdate(ctx context.Context, d *schema.ResourceData, m
 				return diag.Errorf("git_password requires git_password_user_attribute")
 			}
 		}
-		projectGitRepoUpdate.GitPassword = value.(string)
 		if !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "https://") {
 			return diag.Errorf("HTTPS Authentication requires URL starts with https://..")
 		}

--- a/internal/provider/resource_project_git_repo.go
+++ b/internal/provider/resource_project_git_repo.go
@@ -3,11 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/devoteamgcloud/terraform-provider-looker/pkg/lookergo"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"strings"
 )
 
 func resourceProjectGitRepo() *schema.Resource {
@@ -217,6 +218,7 @@ func resourceProjectGitRepoCreate(ctx context.Context, d *schema.ResourceData, m
 			}
 		}
 		payload.GitRemoteUrl = projectGitRepoUpdate.GitRemoteUrl
+		projectGitRepoUpdate.GitUsername = payload.GitUsername
 		projectGitRepoUpdate.GitPassword = payload.GitPassword
 		payload.GitServiceName = projectGitRepoUpdate.GitServiceName
 		if !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "https://") {

--- a/internal/provider/resource_project_git_repo.go
+++ b/internal/provider/resource_project_git_repo.go
@@ -202,45 +202,24 @@ func resourceProjectGitRepoCreate(ctx context.Context, d *schema.ResourceData, m
 		projectGitRepoUpdate.DeploySecret = value.(string)
 	}
 	if value, ok := d.GetOk("git_username"); ok {
-		payload := lookergo.Project{}
-		payload.GitUsername = value.(string)
+		projectGitRepoUpdate.GitUsername = value.(string)
 		if value, ok := d.GetOk("git_password"); ok {
-			payload.GitPassword = value.(string)
+			projectGitRepoUpdate.GitPassword = value.(string)
 		} else {
 			return diag.Errorf("git_username requires git_password")
 		}
 		if value, ok := d.GetOk("git_username_user_attribute"); ok {
-			payload.GitUsernameUserAttribute = value.(string)
+			projectGitRepoUpdate.GitUsernameUserAttribute = value.(string)
 			if value, ok := d.GetOk("git_password_user_attribute"); ok {
-				payload.GitPasswordUserAttribute = value.(string)
+				projectGitRepoUpdate.GitPasswordUserAttribute = value.(string)
 			} else {
 				return diag.Errorf("git_username_user_attribute requires git_password_user_attribute")
 			}
 		}
-		payload.GitRemoteUrl = projectGitRepoUpdate.GitRemoteUrl
-		projectGitRepoUpdate.GitUsername = payload.GitUsername
-		projectGitRepoUpdate.GitPassword = payload.GitPassword
-		projectGitRepoUpdate.GitUsernameUserAttribute = payload.GitUsernameUserAttribute
-		projectGitRepoUpdate.GitPasswordUserAttribute = payload.GitPasswordUserAttribute
-		payload.GitServiceName = projectGitRepoUpdate.GitServiceName
 		if !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "https://") {
 			return diag.Errorf("HTTPS Authentication requires URL starts with http://..")
 		}
-		_, _, err = dc.Projects.Update(ctx, projectName, &payload)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	} else {
-		payload := lookergo.Project{GitRemoteUrl: projectGitRepoUpdate.GitRemoteUrl}
-		if !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "git@") && !strings.HasPrefix(payload.GitRemoteUrl, "ssh://") {
-			return diag.Errorf("SSH Authentication requires URL starts with git@.. or ssh://..")
-		}
-		_, _, err = dc.Projects.Update(ctx, projectName, &payload)
-		if err != nil {
-			return diag.FromErr(err)
-		}
 	}
-
 	_, _, err = dc.Projects.Update(ctx, projectName, &projectGitRepoUpdate)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/resource_project_git_repo.go
+++ b/internal/provider/resource_project_git_repo.go
@@ -323,11 +323,7 @@ func resourceProjectGitRepoUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 		projectGitRepoUpdate.GitPassword = value.(string)
 		if !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "https://") {
-			return diag.Errorf("HTTPS Authentication requires URL starts with http://..")
-		} else {
-			if !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "git@") && !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "ssh://") {
-				return diag.Errorf("SSH Authentication requires URL starts with git@.. or ssh://..")
-			}
+			return diag.Errorf("HTTPS Authentication requires URL starts with https://..")
 		}
 	} else {
 		if !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "git@") && !strings.HasPrefix(projectGitRepoUpdate.GitRemoteUrl, "ssh://") {


### PR DESCRIPTION
This PR addresses several bugs in the project_git_repo resource that were causing authentication failures, incorrect user attribute handling, and validation errors when configuring Git repositories for Looker projects.

Problems Fixed

1. Git credentials not properly assigned in create operation - e5afe242ac116b73385b9782677e74c120c744b5 When using HTTPS authentication with git username/password, the credentials were not being correctly assigned to the main project update payload, causing authentication to fail.
2. Git password assignment bug in update operation - 7e875644055330fb5ad9c16a8996dc05c8843be2 The git password was being assigned from the wrong variable, leading to authentication failures during project updates.
3. User attribute overwrites - c3e7eecbdd25490f4dac52c2968b3aecafcf0190 User attributes for git authentication were not being properly transferred to the main project payload, causing configuration loss.
4. HTTPS URL validation errors during git repo update - c9ab9816e2cd4fbff44a73156ab80ac3ebf3764e validation would always fail because it would always satisfy one of the error check conditions.

I have divided this PR in several small commits to make it easier to review.
